### PR TITLE
Release 1.0.5

### DIFF
--- a/lib/LintResult.js
+++ b/lib/LintResult.js
@@ -16,6 +16,7 @@ class LintResult {
     this.pass = true;
     this.errorCount = 0;
     this.errors = [];
+    this.codesExcluded = [];
   }
 
   setFlowId(flowId) {
@@ -92,6 +93,10 @@ class LintResult {
       this.cleanMessages = [];
     }
     this.cleanMessages.push(message);
+  }
+
+  addExcludedCode(codeId) {
+    this.codesExcluded.push(codeId);
   }
 }
 

--- a/lib/LintRule.js
+++ b/lib/LintRule.js
@@ -62,13 +62,33 @@ class LintRule {
     this.result.setFlowId(mainFlow.flowId);
   }
 
+  setExcludeCodes(excludeRuleCodes) {
+    this.excludeRuleCodes = [];
+
+    excludeRuleCodes?.split(",").forEach((ruleCode) => {
+      const [ruleId, codeId] = ruleCode.split(".");
+
+      if (this.id === ruleId && codeId && this.codes[codeId]) {
+        this.excludeRuleCodes.push(codeId);
+      }
+    });
+  }
+
   /**
-   * Adds an error to the results.
+   * Adds an error to the results.  If the codeId is not found in the
+   * codes table, then an unknown code error is added.  If the codeId
+   * is included in the excludeRuleCodes, then the error is not added.
    *
    * @param {*} codeId  - Result code
    * @param {*} props - Properties to be used when creating error
    */
   addError(codeId, props = {}) {
+    // console.log("Exclude Rule Codes", this.excludeRuleCodes);
+    if (this.excludeRuleCodes?.includes(codeId)) {
+      this.result.addExcludedCode(codeId);
+      return;
+    }
+
     if (codeId) {
       const code = this.codes[codeId];
 

--- a/lib/LintRulePack.js
+++ b/lib/LintRulePack.js
@@ -405,6 +405,9 @@ class LintRulePack {
             // allFlows is an array of all the flows in the bundle, depicting subflows.
             rule.setFlows(mainFlow, allFlows);
 
+            // Set the rule codes to exclude
+            rule.setExcludeCodes(props.excludeRuleCodes);
+
             // Run the rule
             const ruleStartTime = performance.now();
             rule.runRule();

--- a/lib/dvlint
+++ b/lib/dvlint
@@ -65,6 +65,10 @@ program
     "-g, --ignoreRule <ruleName>",
     "specify specific rule(s) to ignore - comma separated list",
   )
+  .option(
+    "-k, --excludeRuleCode <ruleName.code>",
+    "specify specific rule.code(s) to exclude - comma separated list",
+  )
   .option("-j, --json", "returns json in output")
   .option("-t, --table", "returns text table in output. (default)")
   .option("-c, --lintCodes", "print lint codes table")
@@ -169,8 +173,9 @@ if (options.flow) {
 Linting File: ${options.flow}
   Clean File: ${cleanFlowPath || "--no-clean--"}
        Rules: ${options.includeRule || "ALL"}
-     Exclude: ${options.excludeRule || "NONE"}
-      Ignore: ${options.ignoreRule || "NONE"}
+ExcludeRules: ${options.excludeRule || "NONE"}
+ IgnoreRules: ${options.ignoreRule || "NONE"}
+ExcludeCodes: ${options.excludeRuleCode || "NONE"}
 --------------------------------
     `);
   }
@@ -179,6 +184,9 @@ Linting File: ${options.flow}
     includeRules: options.includeRule ? options.includeRule : undefined,
     excludeRules: options.excludeRule ? options.excludeRule : undefined,
     ignoreRules: options.ignoreRule ? options.ignoreRule : undefined,
+    excludeRuleCodes: options.excludeRuleCode
+      ? options.excludeRuleCode
+      : undefined,
     cleanFlow: options.clean !== undefined,
   });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ping-identity/dvlint",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ping-identity/dvlint",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "license": "Apache License 2.0",
       "dependencies": {
         "colors": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ping-identity/dvlint",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "PingOne DaVinci Flow Linter",
   "homepage": "https://library.pingidentity.com/page/davinci-linter-cli",
   "main": "lib/index.js",


### PR DESCRIPTION
Adding the ability to exclude rule codes to the results of a linting:

```
$ lib/dvlint -h
Usage: dvlint [options]

CLI to PingOne DaVinci Linter

Options:
  -V, --version                          output the version number
  -f, --flow <flow.json>                 flow.json, as exported from DaVinci
  -C, --clean                            performs cleaning on the flow and saves it to a CLEAN-{flow}.json after rules are applied
  -d, --diff                             returns differences between the original flow and the cleaned flow
  -R, --rulePacks <rulePack...>          specify a set of rulePacks to use
  -i, --includeRule <ruleName>           specify specific rule(s) to include - comma separated list
  -e, --excludeRule <ruleName>           specify specific rule(s) to exclude - comma separated list
  -g, --ignoreRule <ruleName>            specify specific rule(s) to ignore - comma separated list
  -k, --excludeRuleCode <ruleName.code>  specify specific rule.code(s) to exclude - comma separated list
  -j, --json                             returns json in output
  -t, --table                            returns text table in output. (default)
  -c, --lintCodes                        print lint codes table
  -r, --lintRules                        print lint rules table
  -n, --noColor                          print table with no color
  -a, --ascii                            print table with ascii characters
  -h, --help                             display help for command
```